### PR TITLE
github actions trigger changed to run on push and pull_request

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
-name: Go
-on: [pull_request]
+name: test
+on: [push, pull_request]
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Looks like status badge and last pipeline status of repository doesn't updates itself due to not trigger of pipeline when push on master. 

Added configuration to run on push to trigger pipeline when we merge the request.